### PR TITLE
fixes. uwsgi module parameter was incorrect. migrations folder didn't…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,17 @@ RUN apk add --update --no-cache --virtual=run-deps \
   uwsgi \
   uwsgi-python3 \
   uwsgi-http \
-  python3 \
+  build-base \
+  python3-dev \
   ca-certificates
 
 ENV EXAMPLE_VARIABLE example_value
 
 WORKDIR /opt/deployed
-CMD [ "uwsgi", "--plugins", "http,python3", "--http", "0.0.0.0:3000", "--module", "wsgi" ]
+CMD [ "uwsgi", "--plugins", "http,python3", "--http", "0.0.0.0:3000", "--module", "hi" ]
 
 COPY requirements.txt /opt/deployed/
 RUN pip3 install --no-cache-dir -r /opt/deployed/requirements.txt
 
 COPY *.py /opt/deployed/
-COPY migrations /opt/deployed/migrations
 COPY app /opt/deployed/app


### PR DESCRIPTION
… exist so broke build. had to include build-base and python3-dev to support pytest (typed-ast requirement).